### PR TITLE
Починил график истории звезд

### DIFF
--- a/README.md
+++ b/README.md
@@ -2092,4 +2092,4 @@ Prometheus собирает метрики (нагрузка сервера 1С,
 
 # История звезд
 
-[![Star History Chart](https://api.star-history.com/image?repos=Oxotka/StackTechnologies1C&type=date&legend=top-left)](https://www.star-history.com/?repos=Oxotka%2FStackTechnologies1C&type=date&legend=top-left)
+[![Star History Chart](https://star-history.dera.page/image?repos=Oxotka/StackTechnologies1C&type=date&legend=top-left)](https://star-history.dera.page/#Oxotka%2FStackTechnologies1C&type=date&legend=top-left)


### PR DESCRIPTION
Текущий график истории звезд сломан из-за ограничений GitHub Stargazer API. Переключил его на альтернативный источник данных, который не требует токена, чтобы график снова отображался корректно.